### PR TITLE
pxeverysel.sty: Remove the ctex checking

### DIFF
--- a/pxeverysel.sty
+++ b/pxeverysel.sty
@@ -14,11 +14,6 @@
 \ProvidesPackage{pxeverysel}
     [2016/09/09 v0.4 Patch to everysel for (u)pLaTeX]
 
-%% if ctex classes/packages are already loaded, exit silently
-\ifdefined\CTEXoptions % defined at least CTeX 2007/05/06
-  \expandafter\endinput
-\fi
-
 %% preparations
 \def\pxys@pkgname{pxeverysel}
 \def\pxys@warn{\PackageWarningNoLine\pxys@pkgname}

--- a/pxeverysel.sty
+++ b/pxeverysel.sty
@@ -89,7 +89,7 @@
   \pxys@patch@cmd\pxys@selectfont
     {\pickup@font\font@name}{\size@update\pxys@term}%      % plfonts/ptrace
     {\pickup@font\font@name\pxys@self@hook\pxys@everysel@hook
-     \size@update\enc@update}%
+     \size@update}%
   \ifx\pxys@fragment\relax
     \let\pxys@selectfont\pxys@org@selectfont
     % extract "pre-\enc@update" insertion

--- a/pxeverysel.sty
+++ b/pxeverysel.sty
@@ -107,6 +107,7 @@
   \fi
   \let\pxys@new@selectfont\pxys@selectfont
   % prepare for everysel routine
+  \let\pxys@CheckCommand\CheckCommand
   \let\CheckCommand\@gobble
   % hack for disabling duplicate font info
   \expandafter\let\expandafter\pxys@ver@tracefnt


### PR DESCRIPTION
`ctex` has depended on `pxeverysel` since 2016/12/27 v2.4.7