### PR TITLE
pxeveryshi.sty: LaTeX2e 2020-10-01 対策

### DIFF
--- a/pxeveryshi.sty
+++ b/pxeveryshi.sty
@@ -11,18 +11,27 @@
 \NeedsTeXFormat{pLaTeX2e}
 \ProvidesPackage{pxeveryshi}
     [2012/05/19 v0.1 everyshi package for pLaTeX]
-\RequirePackageWithOptions{everyshi}
 %
-\def\@EveryShipout@Output{%
-  \setbox8\vbox{%
-    \yoko
-    \@EveryShipout@Hook
-    \@EveryShipout@AtNextHook
-    \global\setbox\@cclv=\box\@cclv
-  }%
-  \gdef\@EveryShipout@AtNextHook{}%
-  \@EveryShipout@Org@Shipout\box\@cclv
-}
+\ifx\@EveryShipout@Output\@undefined
+  % LaTeX2e 2020-10-01 or newer simulates everyshi
+  \declare@file@substitution{everyshi.sty}{pxeveryshi.sty}%
+  \long\def\EveryShipout#1{%
+    \AddToHook{shipout/before}{\vbox{\yoko #1}}}%
+  \long\def\AtNextShipout#1{%
+    \AddToHookNext{shipout/before}{\vbox{\yoko #1}}}
+\else
+  \RequirePackageWithOptions{everyshi}
+  \def\@EveryShipout@Output{%
+    \setbox8\vbox{%
+      \yoko
+      \@EveryShipout@Hook
+      \@EveryShipout@AtNextHook
+      \global\setbox\@cclv=\box\@cclv
+    }%
+    \gdef\@EveryShipout@AtNextHook{}%
+    \@EveryShipout@Org@Shipout\box\@cclv
+  }
+\fi
 %
 \endinput
 %% EOF


### PR DESCRIPTION
[aminophen/plautopatch#12](https://github.com/aminophen/plautopatch/issues/12) を調べていて発覚した根本原因の修正案です．ひとまず，向こうの issue で言及した MWE はこれで通るようになります．ただし色々と配慮不足の点があるかもしれませんので，すぐにマージして大丈夫そうかというと，かなり怪しいです．

なお，この変更が plautopatch でも効果を発揮するようにするには，別途 plautopatch.sty に以下を追加する必要があります．

```tex
\platpc@patch@after{everyshi-ltx}{pxeveryshi}% platex-tools
```